### PR TITLE
fix: JSONエクスポート時に.crswapファイルが作成される問題を修正

### DIFF
--- a/docs/js/components/surveyPage.js
+++ b/docs/js/components/surveyPage.js
@@ -160,7 +160,7 @@ const surveyPage = {
 
         const stream = await fileSystemHandle.createWritable()
         await stream.write(blob)
-        await stream.close
+        await stream.close()
 
         console.log(`success: エクスポート. ${fileName}`)
       }


### PR DESCRIPTION
File System Access APIのstream.closeを正しく呼び出すように修正。
これにより評価結果のエクスポート時に.jsonファイルのみが作成されるようになりました。

Fixes #7

Generated with [Claude Code](https://claude.ai/code)