### PR TITLE
fix: エクスポート時に.crswapファイルが作成される問題を修正

### DIFF
--- a/docs/js/components/surveyPage.js
+++ b/docs/js/components/surveyPage.js
@@ -139,7 +139,7 @@ const surveyPage = {
 
         const stream = await fileSystemHandle.createWritable();
         await stream.write(blob);
-        await stream.close;
+        await stream.close();
 
         console.log(`success: エクスポート. ${fileName}`);
       } catch (ex) {


### PR DESCRIPTION
Issue #49 の修正

### 変更内容
- `stream.close` メソッドの呼び出しに `()` を追加
- WritableStreamが適切にクローズされるように修正

### 修正後の動作
- エクスポート時に `.json` ファイルのみが作成される
- `.json.crswap` ファイルは作成されない

Generated with [Claude Code](https://claude.ai/code)