### PR TITLE
feat: upgrade Vue 2.x to Vue 3.x

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
       rel="stylesheet"
     />
     <link
-      href="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.min.css"
+      href="https://cdn.jsdelivr.net/npm/vuetify@3.x/dist/vuetify.min.css"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="css/main.css" />
@@ -23,8 +23,8 @@
         </v-row>
       </v-app>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.x/dist/vue.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vuetify@2.x/dist/vuetify.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@3.x/dist/vue.global.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vuetify@3.x/dist/vuetify.min.js"></script>
     <script src="survey.config.js"></script>
     <script src="js/components/appConfig.js"></script>
     <script src="js/components/assessments.js"></script>

--- a/docs/js/components/surveyPage.js
+++ b/docs/js/components/surveyPage.js
@@ -69,8 +69,8 @@ const surveyPage = {
               top
               offset-y
             >
-              <template v-slot:activator="{ on }">
-                <v-btn v-on="on">削除</v-btn>
+              <template v-slot:activator="{ props }">
+                <v-btn v-bind="props">削除</v-btn>
               </template>
               <v-btn
                 text

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,10 +1,13 @@
-new Vue({
-  el: "#app",
-  vuetify: new Vuetify(),
+const { createApp } = Vue;
+const { createVuetify } = Vuetify;
+
+const vuetify = createVuetify();
+
+createApp({
   components: {
     "survey-page": surveyPage,
   },
   data() {
     return {};
   },
-});
+}).use(vuetify).mount("#app");


### PR DESCRIPTION
Upgrade Vue 2.x to Vue 3.x as requested in issue #51

### Changes:
- Update CDN links from Vue 2 to Vue 3 and Vuetify 2 to Vuetify 3
- Convert new Vue() to createApp() syntax in main.js
- Update Vuetify instantiation to createVuetify()
- Fix v-slot syntax for Vuetify 3 menu activator
- Maintain global script loading pattern and component compatibility

Closes #51

Generated with [Claude Code](https://claude.ai/code)